### PR TITLE
Fix bug where `by` was inverted for sits(above...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased]
 
+* `Fixed`: `by` on sits(aboveTheTopEdgeOf) and sits(aboveTheTopMarginOf) to not be inverted
 * `Added`: MacOS support, this includes all non-margin methods
 * `Fixed`: incorrect GitHub source path in Podspec
 * `Added`: makeSquare()

--- a/Constraid.xcodeproj/project.pbxproj
+++ b/Constraid.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516653851E2D41BF00E28FB3 /* ExpandFromSizeTests.swift */; };
 		516653881E2D489B00E28FB3 /* ManageSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516653871E2D489B00E28FB3 /* ManageSizeTests.swift */; };
+		E9112A611E31A94A00F5CEC5 /* ManageRelativePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */; };
 		E9CAB2A91E21954B00CDA4E2 /* Constraid.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */; };
 		E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CAB2AD1E21954B00CDA4E2 /* ConstraidTests.swift */; };
 		E9CAB2B01E21954B00CDA4E2 /* Constraid.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CAB2A21E21954B00CDA4E2 /* Constraid.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -56,6 +57,7 @@
 		516653851E2D41BF00E28FB3 /* ExpandFromSizeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpandFromSizeTests.swift; sourceTree = "<group>"; };
 		516653871E2D489B00E28FB3 /* ManageSizeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSizeTests.swift; sourceTree = "<group>"; };
 		51E19A9C1E2A82F900998194 /* ExpandFromSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpandFromSize.swift; sourceTree = "<group>"; };
+		E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageRelativePositionTests.swift; sourceTree = "<group>"; };
 		E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Constraid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9CAB2A21E21954B00CDA4E2 /* Constraid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constraid.h; sourceTree = "<group>"; };
 		E9CAB2A31E21954B00CDA4E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				E9CAB2BB1E219A9500CDA4E2 /* PriorityConstructionTests.swift */,
 				516653851E2D41BF00E28FB3 /* ExpandFromSizeTests.swift */,
 				516653871E2D489B00E28FB3 /* ManageSizeTests.swift */,
+				E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */,
 			);
 			path = ConstraidTests;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 				E9CAB2BC1E219A9500CDA4E2 /* PriorityConstructionTests.swift in Sources */,
 				E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */,
 				516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */,
+				E9112A611E31A94A00F5CEC5 /* ManageRelativePositionTests.swift in Sources */,
 				516653881E2D489B00E28FB3 /* ManageSizeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,6 +638,7 @@
 				E9EDB5FA1E2E9F6600C0D060 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Constraid.xcodeproj/xcshareddata/xcschemes/Constraid-MacOS.xcscheme
+++ b/Constraid.xcodeproj/xcshareddata/xcschemes/Constraid-MacOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E9EDB5F21E2E9F6500C0D060"
-               BuildableName = "Constraid-MacOS.framework"
+               BuildableName = "Constraid.framework"
                BlueprintName = "Constraid-MacOS"
                ReferencedContainer = "container:Constraid.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E9EDB5F21E2E9F6500C0D060"
-            BuildableName = "Constraid-MacOS.framework"
+            BuildableName = "Constraid.framework"
             BlueprintName = "Constraid-MacOS"
             ReferencedContainer = "container:Constraid.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E9EDB5F21E2E9F6500C0D060"
-            BuildableName = "Constraid-MacOS.framework"
+            BuildableName = "Constraid.framework"
             BlueprintName = "Constraid-MacOS"
             ReferencedContainer = "container:Constraid.xcodeproj">
          </BuildableReference>

--- a/Constraid/ManageRelativePosition.swift
+++ b/Constraid/ManageRelativePosition.swift
@@ -31,7 +31,7 @@
             NSLayoutConstraint.activate([
                 NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal,
                                    toItem: item, attribute: .topMargin, multiplier: multiplier,
-                                   constant: constant, priority: priority)
+                                   constant: (-1.0 * constant), priority: priority)
                 ])
         }
 
@@ -80,7 +80,7 @@ extension ConstraidView {
         NSLayoutConstraint.activate([
             NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal,
                                toItem: item, attribute: .top, multiplier: multiplier,
-                               constant: constant, priority: priority)
+                               constant: (-1.0 * constant), priority: priority)
             ])
     }
 

--- a/ConstraidTests/ManageRelativePositionTests.swift
+++ b/ConstraidTests/ManageRelativePositionTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+class ManageRelativePositionTests: XCTestCase {
+    func testSitsAboveTheTopEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+        viewOne.sits(aboveTheTopEdgeOf: viewTwo, by: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraint.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraint.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraint.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraint.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraint.constant, -10.0)
+        XCTAssertEqual(constraint.multiplier, 2.0)
+        XCTAssertEqual(constraint.priority, 500)
+    }
+
+    func testSitsAboveTheTopMarginOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+        viewOne.sits(aboveTheTopMarginOf: viewTwo, by: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraint.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraint.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraint.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraint.secondAttribute, NSLayoutAttribute.topMargin)
+        XCTAssertEqual(constraint.constant, -10.0)
+        XCTAssertEqual(constraint.multiplier, 2.0)
+        XCTAssertEqual(constraint.priority, 500)
+    }
+
+}


### PR DESCRIPTION
Why you made the change:

I did this so that the argument actually makes sense in the case where you want to say
something like the following.

    foo.sits(aboveTheTopEdgeOf: bar, by: 45.0)

Previously you would have had to do the following to have it do what you would expect.

    foo.sits(aboveTheTopEdgeOf: bar, by: -45.0)