### PR TITLE
Fix bug where constant in flush(withEdges) didn't behave as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased]
 
+* `Fixed`: issue where flush(withEdgesOf), flush(withVerticalEdgesOf), and
+  flush(withHorizontalEdgesOf) constant argument would not do what expected
 * `Fixed`: `by` on sits(aboveTheTopEdgeOf) and sits(aboveTheTopMarginOf) to not be inverted
 * `Added`: MacOS support, this includes all non-margin methods
 * `Fixed`: incorrect GitHub source path in Podspec

--- a/Constraid.xcodeproj/project.pbxproj
+++ b/Constraid.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516653851E2D41BF00E28FB3 /* ExpandFromSizeTests.swift */; };
 		516653881E2D489B00E28FB3 /* ManageSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516653871E2D489B00E28FB3 /* ManageSizeTests.swift */; };
 		E9112A611E31A94A00F5CEC5 /* ManageRelativePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */; };
+		E9112A631E31AC6100F5CEC5 /* FlushWithEdgesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9112A621E31AC6100F5CEC5 /* FlushWithEdgesTests.swift */; };
 		E9CAB2A91E21954B00CDA4E2 /* Constraid.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */; };
 		E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CAB2AD1E21954B00CDA4E2 /* ConstraidTests.swift */; };
 		E9CAB2B01E21954B00CDA4E2 /* Constraid.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CAB2A21E21954B00CDA4E2 /* Constraid.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -58,6 +59,7 @@
 		516653871E2D489B00E28FB3 /* ManageSizeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSizeTests.swift; sourceTree = "<group>"; };
 		51E19A9C1E2A82F900998194 /* ExpandFromSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpandFromSize.swift; sourceTree = "<group>"; };
 		E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageRelativePositionTests.swift; sourceTree = "<group>"; };
+		E9112A621E31AC6100F5CEC5 /* FlushWithEdgesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlushWithEdgesTests.swift; sourceTree = "<group>"; };
 		E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Constraid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9CAB2A21E21954B00CDA4E2 /* Constraid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constraid.h; sourceTree = "<group>"; };
 		E9CAB2A31E21954B00CDA4E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				516653851E2D41BF00E28FB3 /* ExpandFromSizeTests.swift */,
 				516653871E2D489B00E28FB3 /* ManageSizeTests.swift */,
 				E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */,
+				E9112A621E31AC6100F5CEC5 /* FlushWithEdgesTests.swift */,
 			);
 			path = ConstraidTests;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				E9CAB2BC1E219A9500CDA4E2 /* PriorityConstructionTests.swift in Sources */,
 				E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */,
 				516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */,
+				E9112A631E31AC6100F5CEC5 /* FlushWithEdgesTests.swift in Sources */,
 				E9112A611E31A94A00F5CEC5 /* ManageRelativePositionTests.swift in Sources */,
 				516653881E2D489B00E28FB3 /* ManageSizeTests.swift in Sources */,
 			);

--- a/Constraid/FlushWithEdges.swift
+++ b/Constraid/FlushWithEdges.swift
@@ -59,7 +59,7 @@ extension ConstraidView {
 
         flush(withLeadingEdgeOf: item, constant: constant, multiplier: multiplier,
               priority: priority)
-        flush(withTrailingEdgeOf: item, constant: constant, multiplier: multiplier,
+        flush(withTrailingEdgeOf: item, constant: (-1.0 * constant), multiplier: multiplier,
               priority: priority)
     }
 
@@ -69,7 +69,7 @@ extension ConstraidView {
 
         flush(withTopEdgeOf: item, constant: constant, multiplier: multiplier,
               priority: priority)
-        flush(withBottomEdgeOf: item, constant: constant, multiplier: multiplier,
+        flush(withBottomEdgeOf: item, constant: (-1.0 * constant), multiplier: multiplier,
               priority: priority)
     }
 

--- a/ConstraidTests/FlushWithEdgesTests.swift
+++ b/ConstraidTests/FlushWithEdgesTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+class FlushWithEdgesTests: XCTestCase {
+
+    func testFlushWithVerticalEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+        viewOne.flush(withVerticalEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+
+    func testFlushWithHorizontalEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+        viewOne.flush(withHorizontalEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+
+    func testFlushWithEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+        viewOne.flush(withEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
+        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+
+        XCTAssertEqual(constraintThree.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintThree.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintThree.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintThree.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintThree.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintThree.constant, 10.0)
+        XCTAssertEqual(constraintThree.multiplier, 2.0)
+        XCTAssertEqual(constraintThree.priority, 500)
+
+        XCTAssertEqual(constraintFour.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintFour.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintFour.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintFour.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintFour.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintFour.constant, -10.0)
+        XCTAssertEqual(constraintFour.multiplier, 2.0)
+        XCTAssertEqual(constraintFour.priority, 500)
+    }
+}


### PR DESCRIPTION
Why you made the change:

In order for the constant to act as insets from the flushed edges we have to invert the
trailing and bottom edge constants.