### PR TITLE
Make center methods return constraint collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
+* Fixed bug with `center(horizontallyWithinMarginsOf:)`
+* Changed center methods to return constraint collections
+* Added tests for center within edges and center within margins
 * Changed `centerVertically()` and `centerHorizontally` to
   `center(vertically...)` and `center(horizontally...)`
 * Fixed `flush(withEdge...)` issue where `constant` didn't behave as expected

--- a/Constraid.xcodeproj/project.pbxproj
+++ b/Constraid.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		E9EDB6051E2EA02D00C0D060 /* ExpandFromEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CAB2D31E21D8A300CDA4E2 /* ExpandFromEdge.swift */; };
 		E9EDB6061E2EA03B00C0D060 /* ExpandFromSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E19A9C1E2A82F900998194 /* ExpandFromSize.swift */; };
 		E9EDB6071E2EA04200C0D060 /* ManageIntrinsicSizeRelations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CAB2D11E21A5C500CDA4E2 /* ManageIntrinsicSizeRelations.swift */; };
+		E9EFFFC41E8A5DA100F26BAB /* CenterWithinEdgesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EFFFC21E8A5DA100F26BAB /* CenterWithinEdgesTests.swift */; };
+		E9EFFFC51E8A5DA100F26BAB /* CenterWithinMarginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EFFFC31E8A5DA100F26BAB /* CenterWithinMarginsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +91,8 @@
 		E9EDB5F31E2E9F6500C0D060 /* Constraid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Constraid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9EDB5F51E2E9F6500C0D060 /* Constraid-MacOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Constraid-MacOS.h"; sourceTree = "<group>"; };
 		E9EDB5F61E2E9F6600C0D060 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E9EFFFC21E8A5DA100F26BAB /* CenterWithinEdgesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CenterWithinEdgesTests.swift; sourceTree = "<group>"; };
+		E9EFFFC31E8A5DA100F26BAB /* CenterWithinMarginsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CenterWithinMarginsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +177,8 @@
 				E9112A601E31A94A00F5CEC5 /* ManageRelativePositionTests.swift */,
 				E9112A621E31AC6100F5CEC5 /* FlushWithEdgesTests.swift */,
 				E91BE1FE1E543FFE00861A52 /* FlushWithMarginsTests.swift */,
+				E9EFFFC21E8A5DA100F26BAB /* CenterWithinEdgesTests.swift */,
+				E9EFFFC31E8A5DA100F26BAB /* CenterWithinMarginsTests.swift */,
 			);
 			path = ConstraidTests;
 			sourceTree = "<group>";
@@ -363,10 +369,12 @@
 			files = (
 				E9CAB2BC1E219A9500CDA4E2 /* PriorityConstructionTests.swift in Sources */,
 				E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */,
+				E9EFFFC51E8A5DA100F26BAB /* CenterWithinMarginsTests.swift in Sources */,
 				E91BE2001E54401700861A52 /* FlushWithMarginsTests.swift in Sources */,
 				516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */,
 				E9112A631E31AC6100F5CEC5 /* FlushWithEdgesTests.swift in Sources */,
 				E9112A611E31A94A00F5CEC5 /* ManageRelativePositionTests.swift in Sources */,
+				E9EFFFC41E8A5DA100F26BAB /* CenterWithinEdgesTests.swift in Sources */,
 				516653881E2D489B00E28FB3 /* ManageSizeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Constraid/CenterWithinEdges.swift
+++ b/Constraid/CenterWithinEdges.swift
@@ -6,33 +6,45 @@
 
 extension ConstraidView {
     @discardableResult
-    open func center(verticallyWithin item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+    open func center(verticallyWithin item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         let collection = ConstraidConstraintCollection([
-            NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal,
-                               toItem: item, attribute: .centerY, multiplier: multiplier,
-                               constant: constant, priority: priority)
+            NSLayoutConstraint(item: self, attribute: .centerY,
+                relatedBy: .equal, toItem: item, attribute: .centerY,
+                multiplier: multiplier, constant: constant, priority: priority)
             ])
         collection.activate()
         return collection
     }
 
     @discardableResult
-    open func center(horizontallyWithin item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+    open func center(horizontallyWithin item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         let collection = ConstraidConstraintCollection([
-            NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal,
-                               toItem: item, attribute: .centerX, multiplier: multiplier,
-                               constant: constant, priority: priority)
+            NSLayoutConstraint(item: self, attribute: .centerX,
+                relatedBy: .equal, toItem: item, attribute: .centerX,
+                multiplier: multiplier, constant: constant, priority: priority)
             ])
         collection.activate()
         return collection
     }
 
     @discardableResult
-    open func center(within item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+    open func center(within item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         let constraints = center(horizontallyWithin: item, constant: constant,
                             multiplier: multiplier, priority: priority) +

--- a/Constraid/CenterWithinEdges.swift
+++ b/Constraid/CenterWithinEdges.swift
@@ -5,33 +5,40 @@
 #endif
 
 extension ConstraidView {
-    open func center(verticallyWithin item: Any?, constant: CGFloat = 0.0,
-                               multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func center(verticallyWithin item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal,
                                toItem: item, attribute: .centerY, multiplier: multiplier,
                                constant: constant, priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func center(horizontallyWithin item: Any?, constant: CGFloat = 0.0,
-                                 multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func center(horizontallyWithin item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal,
                                toItem: item, attribute: .centerX, multiplier: multiplier,
                                constant: constant, priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func center(within item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func center(within item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
 
-        self.center(horizontallyWithin: item, constant: constant, multiplier: multiplier,
-                                priority: priority)
-        self.center(verticallyWithin: item, constant: constant, multiplier: multiplier,
-                              priority: priority)
+        let constraints = center(horizontallyWithin: item, constant: constant,
+                            multiplier: multiplier, priority: priority) +
+                          center(verticallyWithin: item, constant: constant,
+                            multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
     }
 }

--- a/Constraid/CenterWithinMargins.swift
+++ b/Constraid/CenterWithinMargins.swift
@@ -4,36 +4,52 @@
 import UIKit
 
 extension ConstraidView {
-    open func center(verticallyWithinMarginsOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+    open func center(verticallyWithinMarginsOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         let collection = ConstraidConstraintCollection([
-            NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal,
-                               toItem: item, attribute: .centerYWithinMargins,
-                               multiplier: multiplier, constant: constant, priority: priority)
+            NSLayoutConstraint(item: self, attribute: .centerY,
+                relatedBy: .equal, toItem: item,
+                attribute: .centerYWithinMargins, multiplier: multiplier,
+                constant: constant, priority: priority)
             ])
         collection.activate()
         return collection
     }
 
-    open func center(horizontallyWithinMarginsOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection{
+    open func center(horizontallyWithinMarginsOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         let collection = ConstraidConstraintCollection([
-            NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal,
-                               toItem: item, attribute: .centerXWithinMargins,
-                               multiplier: multiplier, constant: constant, priority: priority)
+            NSLayoutConstraint(item: self, attribute: .centerX,
+                relatedBy: .equal, toItem: item,
+                attribute: .centerXWithinMargins, multiplier: multiplier,
+                constant: constant, priority: priority)
             ])
         collection.activate()
         return collection
     }
 
-    open func center(withinMarginsOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+    open func center(withinMarginsOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        let constraints = center(horizontallyWithinMarginsOf: item, constant: constant,
-                            multiplier: multiplier, priority: priority) +
-                          center(verticallyWithinMarginsOf: item, constant: constant,
-                            multiplier: multiplier, priority: priority)
+        let constraints = center(horizontallyWithinMarginsOf: item,
+                            constant: constant, multiplier: multiplier,
+                            priority: priority) +
+                          center(verticallyWithinMarginsOf: item,
+                            constant: constant, multiplier: multiplier,
+                            priority: priority)
         constraints.activate()
         return constraints
     }

--- a/Constraid/CenterWithinMargins.swift
+++ b/Constraid/CenterWithinMargins.swift
@@ -4,34 +4,37 @@
 import UIKit
 
 extension ConstraidView {
-    open func center(verticallyWithinMarginsOf item: Any?, constant: CGFloat = 0.0,
-                               multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    open func center(verticallyWithinMarginsOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal,
                                toItem: item, attribute: .centerYWithinMargins,
                                multiplier: multiplier, constant: constant, priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func center(horizontallyWithinMarginsOf item: Any?, constant: CGFloat = 0.0,
-                                 multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    open func center(horizontallyWithinMarginsOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection{
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal,
-                               toItem: item, attribute: .centerYWithinMargins,
+                               toItem: item, attribute: .centerXWithinMargins,
                                multiplier: multiplier, constant: constant, priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func center(withinMarginsOf item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    open func center(withinMarginsOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
 
-        self.center(horizontallyWithinMarginsOf: item, constant: constant,
-                                multiplier: multiplier, priority: priority)
-        self.center(verticallyWithinMarginsOf: item, constant: constant,
-                              multiplier: multiplier, priority: priority)
+        let constraints = center(horizontallyWithinMarginsOf: item, constant: constant,
+                            multiplier: multiplier, priority: priority) +
+                          center(verticallyWithinMarginsOf: item, constant: constant,
+                            multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
     }
 }

--- a/ConstraidTests/CenterWithinEdgesTests.swift
+++ b/ConstraidTests/CenterWithinEdgesTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import Constraid
+
+class CenterWithinEdgesTests: XCTestCase {
+    func testCenterVerticallyWithin() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.center(verticallyWithin: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.centerY)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.centerY)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testCenterHorizontallyWithin() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.center(horizontallyWithin: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.centerX)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.centerX)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testCenterWithin() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.center(within: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.centerX)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.centerX)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.centerY)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.centerY)
+        XCTAssertEqual(constraintTwo.constant, 10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+}

--- a/ConstraidTests/CenterWithinMarginsTests.swift
+++ b/ConstraidTests/CenterWithinMarginsTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import Constraid
+
+class CenterWithinMarginsTests: XCTestCase {
+    func testCenterVerticallyWithinMargins() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.center(verticallyWithinMarginsOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.centerY)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.centerYWithinMargins)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testCenterHorizontallyWithinMargins() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.center(horizontallyWithinMarginsOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.centerX)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.centerXWithinMargins)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testCenterWithinMargins() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.center(withinMarginsOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.centerX)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.centerXWithinMargins)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.centerY)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.equal)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.centerYWithinMargins)
+        XCTAssertEqual(constraintTwo.constant, 10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+}


### PR DESCRIPTION
Why you made the change:

I did this so that the collections of the constraints can easily be
stored and can be used to activate/deactivate a set of constraints, or
so that they can be used in animations. I also backfilled test coverage
for these methods. Beyond, that I fixed a bug in one of the methods were
it tried to set the centerXWithinMargins based on centerY.

This should resolve issue #4 and #5.