### PR TITLE
Add the deprecated flush(withMargins.. methods back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
+* Deprecated `flush(withMarginsOf:, constant:)` use `flush(withMarginsOf:, insetBy:)`
 * Deprecated `flush(withEdgesOf:, constant:)` use `flush(withEdgesOf:, insetBy:)`
 * Deprecated `centerVertically` & `centerHorizontally` use `center(vertically...)` and `center(horizontally...)`
 * Fixed bug with `center(horizontallyWithinMarginsOf:)`

--- a/Constraid/FlushWithMargins.swift
+++ b/Constraid/FlushWithMargins.swift
@@ -108,4 +108,105 @@ extension ConstraidView {
         constraints.activate()
         return constraints
     }
+
+    // MARK: - Deprecated
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withLeadingMarginOf: , insetBy: ...)")
+    open func flush(withLeadingMarginOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .equal,
+                               toItem: item, attribute: .leadingMargin, multiplier: multiplier,
+                               constant: constant, priority: priority)
+            ])
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withTrailingMarginOf: , insetBy: ...)")
+    open func flush(withTrailingMarginOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .trailing, relatedBy: .equal,
+                               toItem: item, attribute: .trailingMargin, multiplier: multiplier,
+                               constant: (-1.0 * constant), priority: priority)
+            ])
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withTopMarginOf: , insetBy: ...)")
+    open func flush(withTopMarginOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .top, relatedBy: .equal,
+                               toItem: item, attribute: .topMargin, multiplier: multiplier,
+                               constant: constant, priority: priority)
+            ])
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withBottomMarginOf: , insetBy: ...)")
+    open func flush(withBottomMarginOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal,
+                               toItem: item, attribute: .bottomMargin, multiplier: multiplier,
+                               constant: (-1.0 * constant), priority: priority)
+            ])
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withVerticalMarginsOf: , insetBy: ...)")
+    open func flush(withVerticalMarginsOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        let constraints = flush(withLeadingMarginOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          flush(withTrailingMarginOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withHorizontalMarginsOf: , insetBy: ...)")
+    open func flush(withHorizontalMarginsOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        let constraints = flush(withTopMarginOf: item, constant: constant, multiplier: multiplier,
+                                priority: priority) +
+                          flush(withBottomMarginOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withMarginsOf: , insetBy: ...)")
+    open func flush(withMarginsOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        let constraints = flush(withHorizontalMarginsOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          flush(withVerticalMarginsOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
 }


### PR DESCRIPTION
Why you made the change:

I did this so that we wouldn't be taking such a harsh stance for people
using our library. Instead we will give them a major release to deal
with the deprecations and then eliminate them in the major release
following that one. *Note:* I did include the backward compatible
changes to these methods and the bug fixes to these methods as our users
should still receive those in my opinion.