### PR TITLE
Add the deprecated flush(withEdges.. methods back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
+* Deprecated `flush(withEdgesOf:, constant:)` use `flush(withEdgesOf:, insetBy:)`
 * Deprecated `centerVertically` & `centerHorizontally` use `center(vertically...)` and `center(horizontally...)`
 * Fixed bug with `center(horizontallyWithinMarginsOf:)`
 * Changed center methods to return constraint collections

--- a/Constraid/FlushWithEdges.swift
+++ b/Constraid/FlushWithEdges.swift
@@ -103,4 +103,111 @@ extension ConstraidView {
         constraints.activate()
         return constraints
     }
+
+    // MARK: - Deprecated
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withLeadigEdgeOf: , insetBy: ...)")
+    public func flush(withLeadingEdgeOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .equal,
+                               toItem: item, attribute: .leading, multiplier: multiplier,
+                               constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withTrailingEdgeOf: , insetBy: ...)")
+    public func flush(withTrailingEdgeOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .trailing, relatedBy: .equal,
+                               toItem: item, attribute: .trailing, multiplier: multiplier,
+                               constant: (-1.0 * constant), priority: priority)
+            ])
+        collection.activate()
+        return collection
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withTopEdgeOf: , insetBy: ...)")
+    public func flush(withTopEdgeOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .top, relatedBy: .equal,
+                               toItem: item, attribute: .top, multiplier: multiplier,
+                               constant: constant, priority: priority)
+            ])
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withBottomEdgeOf: , insetBy: ...)")
+    public func flush(withBottomEdgeOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal,
+                               toItem: item, attribute: .bottom, multiplier: multiplier,
+                               constant: (-1.0 * constant), priority: priority)
+            ])
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use insetBy flush(withVerticalEdgesOf: , insetBy: ...)")
+    public func flush(withVerticalEdgesOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        let constraints = flush(withLeadingEdgeOf: item, constant: constant, multiplier: multiplier,
+                                priority: priority) +
+                          flush(withTrailingEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withHorizontalEdgesOf: , insetBy: ...)")
+    public func flush(withHorizontalEdgesOf item: Any?, constant: CGFloat = 0.0,
+                    multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+
+        let constraints = flush(withTopEdgeOf: item, constant: constant, multiplier: multiplier,
+                                priority: priority) +
+                          flush(withBottomEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use flush(withEdgesOf: , insetBy: ...)")
+    public func flush(withEdgesOf item: Any?, constant: CGFloat = 0.0, multiplier: CGFloat = 1.0,
+                    priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) -> ConstraidConstraintCollection {
+        
+        let constraints = flush(withHorizontalEdgesOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          flush(withVerticalEdgesOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
 }


### PR DESCRIPTION
Why you made the change:

I did this so that we wouldn't be taking such a harsh stance for people
using our library. Instead we will give them a major release to deal
with the deprecations and then eliminate them in the major release
following that one. *Note:* I did include the backward compatible
changes to these methods and the bug fixes to these methods as our users
should still receive those in my opinion.