### PR TITLE
Add the deprecated centerVertically & centerHorizontally methods back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
+* Deprecated `centerVertically` & `centerHorizontally` use `center(vertically...)` and `center(horizontally...)`
 * Fixed bug with `center(horizontallyWithinMarginsOf:)`
 * Changed center methods to return constraint collections
 * Added tests for center within edges and center within margins

--- a/Constraid/CenterWithinEdges.swift
+++ b/Constraid/CenterWithinEdges.swift
@@ -53,4 +53,42 @@ extension ConstraidView {
         constraints.activate()
         return constraints
     }
+
+    // MARK: - Deprecated
+
+    @discardableResult
+    @available(*, deprecated, message: "use center(verticallyWithin: ...)")
+    open func centerVertically(within item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .centerY,
+                relatedBy: .equal, toItem: item, attribute: .centerY,
+                multiplier: multiplier, constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use center(horizontallyWithin: ...)")
+    open func centerHorizontally(within item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .centerX,
+                relatedBy: .equal, toItem: item, attribute: .centerX,
+                multiplier: multiplier, constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
+    }
 }

--- a/Constraid/CenterWithinMargins.swift
+++ b/Constraid/CenterWithinMargins.swift
@@ -56,4 +56,44 @@ extension ConstraidView {
         constraints.activate()
         return constraints
     }
+
+    // MARK: - Deprecated
+
+    @discardableResult
+    @available(*, deprecated, message: "use center(verticallyWithinMarginsOf: ...)")
+    open func centerVertically(withinMarginsOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .centerY,
+                relatedBy: .equal, toItem: item,
+                attribute: .centerYWithinMargins, multiplier: multiplier,
+                constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
+    }
+
+    @discardableResult
+    @available(*, deprecated, message: "use center(horizontallyWithinMarginsOf: ...)")
+    open func centerHorizontally(withinMarginsOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .centerX,
+                relatedBy: .equal, toItem: item,
+                attribute: .centerXWithinMargins, multiplier: multiplier,
+                constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
+    }
 }


### PR DESCRIPTION
Why you made the change:

I did this so that we wouldn't be taking such a harsh stance for people
using our library. Instead we will give them a major release to deal
with the deprecations and then eliminate them in the major release
following that one. *Note:* I did include the backward compatible
changes to these methods and the bug fixes to these methods as our users
should still receive those in my opinion.