### PR TITLE
Backfill tests for limit(byEdgesOf:) family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
+* Backfilled test for `limit(byEdgesOf:)` family of methods
+* Fixed bug with `limit(byBottomEdgeOf:)` treating `constant` as a positive
+* Fixed bug with `limit(byTrailingEdgeOf:)` treating `constant` as a positive
+* Changed `limit(byEdgesOf:)` family to return collection of constraints
 * Deprecated `flush(withMarginsOf:, constant:)` use `flush(withMarginsOf:, insetBy:)`
 * Deprecated `flush(withEdgesOf:, constant:)` use `flush(withEdgesOf:, insetBy:)`
 * Deprecated `centerVertically` & `centerHorizontally` use `center(vertically...)` and `center(horizontally...)`

--- a/Constraid.xcodeproj/project.pbxproj
+++ b/Constraid.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		E91BE1FC1E54062800861A52 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91BE1FB1E54062800861A52 /* Constraint.swift */; };
 		E91BE1FD1E54062800861A52 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91BE1FB1E54062800861A52 /* Constraint.swift */; };
 		E91BE2001E54401700861A52 /* FlushWithMarginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91BE1FE1E543FFE00861A52 /* FlushWithMarginsTests.swift */; };
+		E984AB041E8CE904009C64A0 /* LimitByEdgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E984AB031E8CE904009C64A0 /* LimitByEdgeTests.swift */; };
 		E99C6E321E530E1A00C72E5E /* ConstraintCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99C6E311E530E1A00C72E5E /* ConstraintCollection.swift */; };
 		E99C6E331E530E2000C72E5E /* ConstraintCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99C6E311E530E1A00C72E5E /* ConstraintCollection.swift */; };
 		E9CAB2A91E21954B00CDA4E2 /* Constraid.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */; };
@@ -67,6 +68,7 @@
 		E9112A621E31AC6100F5CEC5 /* FlushWithEdgesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlushWithEdgesTests.swift; sourceTree = "<group>"; };
 		E91BE1FB1E54062800861A52 /* Constraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constraint.swift; sourceTree = "<group>"; };
 		E91BE1FE1E543FFE00861A52 /* FlushWithMarginsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlushWithMarginsTests.swift; sourceTree = "<group>"; };
+		E984AB031E8CE904009C64A0 /* LimitByEdgeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitByEdgeTests.swift; sourceTree = "<group>"; };
 		E99C6E311E530E1A00C72E5E /* ConstraintCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintCollection.swift; sourceTree = "<group>"; };
 		E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Constraid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9CAB2A21E21954B00CDA4E2 /* Constraid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constraid.h; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				E91BE1FE1E543FFE00861A52 /* FlushWithMarginsTests.swift */,
 				E9EFFFC21E8A5DA100F26BAB /* CenterWithinEdgesTests.swift */,
 				E9EFFFC31E8A5DA100F26BAB /* CenterWithinMarginsTests.swift */,
+				E984AB031E8CE904009C64A0 /* LimitByEdgeTests.swift */,
 			);
 			path = ConstraidTests;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				E9CAB2BC1E219A9500CDA4E2 /* PriorityConstructionTests.swift in Sources */,
 				E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */,
 				E9EFFFC51E8A5DA100F26BAB /* CenterWithinMarginsTests.swift in Sources */,
+				E984AB041E8CE904009C64A0 /* LimitByEdgeTests.swift in Sources */,
 				E91BE2001E54401700861A52 /* FlushWithMarginsTests.swift in Sources */,
 				516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */,
 				E9112A631E31AC6100F5CEC5 /* FlushWithEdgesTests.swift in Sources */,

--- a/Constraid/LimitByEdge.swift
+++ b/Constraid/LimitByEdge.swift
@@ -5,78 +5,122 @@
 #endif
 
 extension ConstraidView {
-    open func limit(byBottomEdgeOf item: Any?, constant: CGFloat = 0.0,
-                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func limit(byLeadingEdgeOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .lessThanOrEqual,
-                               toItem: item, attribute: .bottom, multiplier: multiplier,
-                               constant: constant, priority: priority)
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .leading,
+                relatedBy: .lessThanOrEqual, toItem: item, attribute: .leading,
+                multiplier: multiplier, constant: constant, priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func limit(byTopEdgeOf item: Any?, constant: CGFloat = 0.0,
-                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func limit(byTrailingEdgeOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            NSLayoutConstraint(item: self, attribute: .top, relatedBy: .lessThanOrEqual,
-                               toItem: item, attribute: .top, multiplier: multiplier, constant: constant,
-                               priority: priority)
-            ])
-    }
-
-    open func limit(byLeadingEdgeOf item: Any?, constant: CGFloat = 0.0,
-                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
-
-        self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .lessThanOrEqual,
-                               toItem: item, attribute: .leading, multiplier: multiplier,
-                               constant: constant, priority: priority)
-            ])
-    }
-
-    open func limit(byTrailingEdgeOf item: Any?, constant: CGFloat = 0.0,
-                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
-
-        self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .trailing,
-                               relatedBy: .lessThanOrEqual, toItem: item, attribute: .trailing,
-                               multiplier: multiplier, constant: constant, priority: priority)
+                relatedBy: .lessThanOrEqual, toItem: item,
+                attribute: .trailing, multiplier: multiplier,
+                constant: (constant * -1), priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func limit(byHorizontalEdgesOf item: Any?, constant: CGFloat = 0.0,
-                              multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func limit(byTopEdgeOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        limit(byTopEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
-        limit(byBottomEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .top,
+                relatedBy: .lessThanOrEqual, toItem: item, attribute: .top,
+                multiplier: multiplier, constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
     }
 
-    open func limit(byVerticalEdgesOf item: Any?, constant: CGFloat = 0.0,
-                                multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func limit(byBottomEdgeOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        limit(byLeadingEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
-        limit(byTrailingEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .bottom,
+                relatedBy: .lessThanOrEqual, toItem: item, attribute: .bottom,
+                multiplier: multiplier, constant: (constant * -1),
+                priority: priority)
+            ])
+        collection.activate()
+        return collection
     }
 
-    open func limit(byEdgesOf item: Any?, constant: CGFloat = 0.0,
-                    multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func limit(byHorizontalEdgesOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        limit(byTopEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
-        limit(byBottomEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
-        limit(byLeadingEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
-        limit(byTrailingEdgeOf: item, constant: constant, multiplier: multiplier,
-              priority: priority)
+        let constraints = limit(byTopEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          limit(byBottomEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    open func limit(byVerticalEdgesOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        let constraints = limit(byLeadingEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          limit(byTrailingEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
+    }
+
+    @discardableResult
+    open func limit(byEdgesOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        let constraints = limit(byTopEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          limit(byBottomEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          limit(byLeadingEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority) +
+                          limit(byTrailingEdgeOf: item, constant: constant,
+                                multiplier: multiplier, priority: priority)
+        constraints.activate()
+        return constraints
     }
 }

--- a/ConstraidTests/LimitByEdgeTests.swift
+++ b/ConstraidTests/LimitByEdgeTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+import Constraid
+
+class LimitByEdgeTests: XCTestCase {
+    func testLimitByLeadingEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byLeadingEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testLimitByTrailingEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byTrailingEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintOne.constant, -10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testLimitByTopEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byTopEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testLimitByBottomEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byBottomEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintOne.constant, -10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testLimitByHorizontalEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byHorizontalEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+
+    func testLimitByVerticalEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byVerticalEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+
+    func testLimitByEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.limit(byEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
+        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+
+        XCTAssertEqual(constraintThree.isActive, true)
+        XCTAssertEqual(constraintThree.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintThree.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintThree.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintThree.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintThree.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintThree.constant, 10.0)
+        XCTAssertEqual(constraintThree.multiplier, 2.0)
+        XCTAssertEqual(constraintThree.priority, 500)
+
+        XCTAssertEqual(constraintFour.isActive, true)
+        XCTAssertEqual(constraintFour.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintFour.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintFour.relation, NSLayoutRelation.lessThanOrEqual)
+        XCTAssertEqual(constraintFour.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintFour.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintFour.constant, -10.0)
+        XCTAssertEqual(constraintFour.multiplier, 2.0)
+        XCTAssertEqual(constraintFour.priority, 500)
+    }
+}


### PR DESCRIPTION
Why you made the change:

I did a number of things in this PR.

- Backfilled tests for the limit(byEdgesOf:) family of methods

I did this so that we would have good test coverage.

- Fixed bug with limit(byBottomEdgeOf:) treating constant as a positive

I did this so that the method would behave as expected rather than
non-intuitively going the opposite direction.

- Fixed bug with limit(byTrailingEdgeOf:) treating constant as a positive

I did this so that the method would behave as expected rather than
non-intuitively going the opposite direction.

- Changed limit(byEdgesOf:) family to return collection of constraints

I did this so that people would be able to use the collections to
autolayout based animations easily, etc.