### PR TITLE
Backfill test for expand(from...) family of functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
-* Changed `limit(byMarginsOf:)` family to return collection of constraints
+* Backfilled test for `expand(fromEdgesOf:)` family of methods
+* Fixed bug with `expand(fromBottomEdgeOf:)` treating `constant` as a positive
+  **breaking change**
+* Fixed bug with `expand(fromTrailingEdgeOf:)` treating `constant` as a positive
+  **breaking change**
+* Changed `expand(fromEdgesOf:)` family to return collection of constraints
 * Backfilled test for `limit(byMarginsOf:)` family of methods
 * Fixed bug with `limit(byBottomMarginOf:)` treating `constant` as a positive
   **breaking change**
 * Fixed bug with `limit(byTrailingMarginOf:)` treating `constant` as a positive
   **breaking change**
+* Changed `limit(byMarginsOf:)` family to return collection of constraints
 * Backfilled test for `limit(byEdgesOf:)` family of methods
 * Fixed bug with `limit(byBottomEdgeOf:)` treating `constant` as a positive
   **breaking change**

--- a/Constraid.xcodeproj/project.pbxproj
+++ b/Constraid.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		E99C6E321E530E1A00C72E5E /* ConstraintCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99C6E311E530E1A00C72E5E /* ConstraintCollection.swift */; };
 		E99C6E331E530E2000C72E5E /* ConstraintCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99C6E311E530E1A00C72E5E /* ConstraintCollection.swift */; };
 		E9C0FE531EAAD0FD003FCF15 /* LimitByMarginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C0FE511EAAD0F3003FCF15 /* LimitByMarginTests.swift */; };
+		E9C0FE551EAAE4B3003FCF15 /* ExpandFromEdgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C0FE541EAAE4B3003FCF15 /* ExpandFromEdgeTests.swift */; };
 		E9CAB2A91E21954B00CDA4E2 /* Constraid.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */; };
 		E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CAB2AD1E21954B00CDA4E2 /* ConstraidTests.swift */; };
 		E9CAB2B01E21954B00CDA4E2 /* Constraid.h in Headers */ = {isa = PBXBuildFile; fileRef = E9CAB2A21E21954B00CDA4E2 /* Constraid.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -72,6 +73,7 @@
 		E984AB031E8CE904009C64A0 /* LimitByEdgeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitByEdgeTests.swift; sourceTree = "<group>"; };
 		E99C6E311E530E1A00C72E5E /* ConstraintCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintCollection.swift; sourceTree = "<group>"; };
 		E9C0FE511EAAD0F3003FCF15 /* LimitByMarginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitByMarginTests.swift; sourceTree = "<group>"; };
+		E9C0FE541EAAE4B3003FCF15 /* ExpandFromEdgeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpandFromEdgeTests.swift; sourceTree = "<group>"; };
 		E9CAB29F1E21954B00CDA4E2 /* Constraid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Constraid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9CAB2A21E21954B00CDA4E2 /* Constraid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constraid.h; sourceTree = "<group>"; };
 		E9CAB2A31E21954B00CDA4E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				E9EFFFC31E8A5DA100F26BAB /* CenterWithinMarginsTests.swift */,
 				E984AB031E8CE904009C64A0 /* LimitByEdgeTests.swift */,
 				E9C0FE511EAAD0F3003FCF15 /* LimitByMarginTests.swift */,
+				E9C0FE541EAAE4B3003FCF15 /* ExpandFromEdgeTests.swift */,
 			);
 			path = ConstraidTests;
 			sourceTree = "<group>";
@@ -377,6 +380,7 @@
 				E9CAB2AE1E21954B00CDA4E2 /* ConstraidTests.swift in Sources */,
 				E9EFFFC51E8A5DA100F26BAB /* CenterWithinMarginsTests.swift in Sources */,
 				E984AB041E8CE904009C64A0 /* LimitByEdgeTests.swift in Sources */,
+				E9C0FE551EAAE4B3003FCF15 /* ExpandFromEdgeTests.swift in Sources */,
 				E91BE2001E54401700861A52 /* FlushWithMarginsTests.swift in Sources */,
 				516653861E2D41BF00E28FB3 /* ExpandFromSizeTests.swift in Sources */,
 				E9112A631E31AC6100F5CEC5 /* FlushWithEdgesTests.swift in Sources */,

--- a/Constraid/ExpandFromEdge.swift
+++ b/Constraid/ExpandFromEdge.swift
@@ -5,78 +5,119 @@
 #endif
 
 extension ConstraidView {
-    open func expand(fromBottomEdgeOf item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func expand(fromLeadingEdgeOf item: Any?,
+        constant: CGFloat = 0.0, multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            NSLayoutConstraint(item: self, attribute: .bottom,
-                               relatedBy: .greaterThanOrEqual, toItem: item, attribute: .bottom,
-                               multiplier: multiplier, constant: constant, priority: priority)
-            ])
-    }
-
-    open func expand(fromTopEdgeOf item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
-
-        self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            NSLayoutConstraint(item: self, attribute: .top,
-                               relatedBy: .greaterThanOrEqual, toItem: item, attribute: .top,
-                               multiplier: multiplier, constant: constant, priority: priority)
-            ])
-    }
-
-    open func expand(fromLeadingEdgeOf item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
-
-        self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .leading,
-                               relatedBy: .greaterThanOrEqual, toItem: item, attribute: .leading,
-                               multiplier: multiplier, constant: constant, priority: priority)
+                relatedBy: .greaterThanOrEqual, toItem: item,
+                attribute: .leading, multiplier: multiplier,
+                constant: constant, priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func expand(fromTrailingEdgeOf item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func expand(fromTrailingEdgeOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
         self.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
+        let collection = ConstraidConstraintCollection([
             NSLayoutConstraint(item: self, attribute: .trailing,
-                               relatedBy: .greaterThanOrEqual, toItem: item, attribute: .trailing,
-                               multiplier: multiplier, constant: constant, priority: priority)
+                relatedBy: .greaterThanOrEqual, toItem: item,
+                attribute: .trailing, multiplier: multiplier,
+                constant: (constant * -1), priority: priority)
             ])
+        collection.activate()
+        return collection
     }
 
-    open func expand(fromHorizontalEdgesOf item: Any?, constant: CGFloat = 0.0,
-                               multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func expand(fromTopEdgeOf item: Any?,
+        constant: CGFloat = 0.0, multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        expand(fromTopEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
-        expand(fromBottomEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .top,
+                relatedBy: .greaterThanOrEqual, toItem: item, attribute: .top,
+                multiplier: multiplier, constant: constant, priority: priority)
+            ])
+        collection.activate()
+        return collection
     }
 
-    open func expand(fromVerticalEdgesOf item: Any?, constant: CGFloat = 0.0,
-                                 multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func expand(fromBottomEdgeOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        expand(fromLeadingEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
-        expand(fromTrailingEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        let collection = ConstraidConstraintCollection([
+            NSLayoutConstraint(item: self, attribute: .bottom,
+                relatedBy: .greaterThanOrEqual, toItem: item,
+                attribute: .bottom, multiplier: multiplier,
+                constant: (constant * -1), priority: priority)
+            ])
+        collection.activate()
+        return collection
     }
 
-    open func expand(fromEdgesOf item: Any?, constant: CGFloat = 0.0,
-                     multiplier: CGFloat = 1.0, priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired) {
+    @discardableResult
+    open func expand(fromHorizontalEdgesOf item: Any?,
+        constant: CGFloat = 0.0,
+        multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
 
-        expand(fromTopEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
-        expand(fromBottomEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
-        expand(fromLeadingEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
-        expand(fromTrailingEdgeOf: item, constant: constant, multiplier: multiplier,
-               priority: priority)
+        let collection = expand(fromTopEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority) +
+                         expand(fromBottomEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority)
+        collection.activate()
+        return collection
+    }
+
+    @discardableResult
+    open func expand(fromVerticalEdgesOf item: Any?,
+        constant: CGFloat = 0.0, multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        let collection = expand(fromLeadingEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority) +
+                         expand(fromTrailingEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority)
+        collection.activate()
+        return collection
+    }
+
+    @discardableResult
+    open func expand(fromEdgesOf item: Any?,
+        constant: CGFloat = 0.0, multiplier: CGFloat = 1.0,
+        priority: ConstraidLayoutPriority = ConstraidLayoutPriorityRequired
+        ) -> ConstraidConstraintCollection {
+
+        let collection = expand(fromTopEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority) +
+                         expand(fromBottomEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority) +
+                         expand(fromLeadingEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority) +
+                         expand(fromTrailingEdgeOf: item, constant: constant,
+                             multiplier: multiplier, priority: priority)
+        collection.activate()
+        return collection
     }
 }

--- a/ConstraidTests/ExpandFromEdgeTests.swift
+++ b/ConstraidTests/ExpandFromEdgeTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+import Constraid
+
+class ExpandFromEdgeTests: XCTestCase {
+    func testExpandFromLeadingEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromLeadingEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testExpandByTrailingEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromTrailingEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintOne.constant, -10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testExpandFromTopEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromTopEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testExpandFromBottomEdgeOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromBottomEdgeOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintOne.constant, -10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+    }
+
+    func testExpandFromHorizontalEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromHorizontalEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+
+    func testExpandFromVerticalEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromVerticalEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+    }
+
+    func testExpandFromEdgesOf() {
+        let viewOne = UIView()
+        let viewTwo = UIView()
+
+        viewOne.addSubview(viewTwo)
+
+        let constraints = viewOne.expand(fromEdgesOf: viewTwo, constant: 10.0, multiplier: 2.0, priority: 500)
+
+        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
+        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
+        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+
+        XCTAssertEqual(constraintOne.isActive, true)
+        XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintOne.firstAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintOne.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintOne.secondAttribute, NSLayoutAttribute.top)
+        XCTAssertEqual(constraintOne.constant, 10.0)
+        XCTAssertEqual(constraintOne.multiplier, 2.0)
+        XCTAssertEqual(constraintOne.priority, 500)
+
+        XCTAssertEqual(constraintTwo.isActive, true)
+        XCTAssertEqual(constraintTwo.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintTwo.firstAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintTwo.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintTwo.secondAttribute, NSLayoutAttribute.bottom)
+        XCTAssertEqual(constraintTwo.constant, -10.0)
+        XCTAssertEqual(constraintTwo.multiplier, 2.0)
+        XCTAssertEqual(constraintTwo.priority, 500)
+
+        XCTAssertEqual(constraintThree.isActive, true)
+        XCTAssertEqual(constraintThree.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintThree.firstAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintThree.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintThree.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintThree.secondAttribute, NSLayoutAttribute.leading)
+        XCTAssertEqual(constraintThree.constant, 10.0)
+        XCTAssertEqual(constraintThree.multiplier, 2.0)
+        XCTAssertEqual(constraintThree.priority, 500)
+
+        XCTAssertEqual(constraintFour.isActive, true)
+        XCTAssertEqual(constraintFour.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraintFour.firstAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintFour.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertEqual(constraintFour.secondItem as! UIView, viewTwo)
+        XCTAssertEqual(constraintFour.secondAttribute, NSLayoutAttribute.trailing)
+        XCTAssertEqual(constraintFour.constant, -10.0)
+        XCTAssertEqual(constraintFour.multiplier, 2.0)
+        XCTAssertEqual(constraintFour.priority, 500)
+    }
+}


### PR DESCRIPTION
Why you made the change:

I did this so that we would have confidence that they are working as
expected and give us confidence to refactor. I also fixed the constant
bugs in the expand(fromBottomEdgeOf:) and expand(fromTrailingEdgeOf:)
methods so that it behaves as expected now. Beyond that I modified the
methods to return the collection of constraints.