### PR TITLE
Remove useless constraint casts in tests

### DIFF
--- a/ConstraidTests/CenterWithinEdgesTests.swift
+++ b/ConstraidTests/CenterWithinEdgesTests.swift
@@ -9,7 +9,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithin: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .down, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -32,7 +32,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithin: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .up, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -55,7 +55,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithin: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .right, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -78,7 +78,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithin: viewTwo,  times: 2.0, offsetBy: 10.0, offsetDirection: .left,priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -102,8 +102,8 @@ class CenterWithinEdgesTests: XCTestCase {
 
         let constraints = Constraid.center(viewOne, within: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .downAndRight, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -138,8 +138,8 @@ class CenterWithinEdgesTests: XCTestCase {
 
         let constraints = Constraid.center(viewOne, within: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .upAndLeft, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/CenterWithinMarginsTests.swift
+++ b/ConstraidTests/CenterWithinMarginsTests.swift
@@ -9,7 +9,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .down, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -32,7 +32,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .up, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -55,7 +55,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .right, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -78,7 +78,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithinMarginsOf: viewTwo, times: 2.0,  offsetBy: 10.0, offsetDirection: .left,priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -102,8 +102,8 @@ class CenterWithinMarginsTests: XCTestCase {
 
         let constraints = Constraid.center(viewOne, withinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .downAndRight, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -138,8 +138,8 @@ class CenterWithinMarginsTests: XCTestCase {
 
         let constraints = Constraid.center(viewOne, withinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .upAndLeft, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/ConstraintCollectionTests.swift
+++ b/ConstraidTests/ConstraintCollectionTests.swift
@@ -27,7 +27,7 @@ class ConstraintCollectionTests: XCTestCase {
 
         constraints.activate()
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -47,7 +47,7 @@ class ConstraintCollectionTests: XCTestCase {
 
         constraints.deactivate()
 
-        let constraintOne = constraints.first! as NSLayoutConstraint
+        let constraintOne = constraints.first!
 
         XCTAssertEqual(viewOne.constraints, [])
         XCTAssertEqual(constraintOne.isActive, false)

--- a/ConstraidTests/CupByEdgeTests.swift
+++ b/ConstraidTests/CupByEdgeTests.swift
@@ -9,9 +9,9 @@ class CupByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byLeadingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -55,9 +55,9 @@ class CupByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTrailingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -101,9 +101,9 @@ class CupByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTopEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -147,9 +147,9 @@ class CupByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byBottomEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/CupByMarginTests.swift
+++ b/ConstraidTests/CupByMarginTests.swift
@@ -9,9 +9,9 @@ class CupByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byLeadingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -55,9 +55,9 @@ class CupByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTrailingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -101,9 +101,9 @@ class CupByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTopMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -147,9 +147,9 @@ class CupByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byBottomMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/ExpandFromEdgeTests.swift
+++ b/ConstraidTests/ExpandFromEdgeTests.swift
@@ -9,7 +9,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromLeadingEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -32,7 +32,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTrailingEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -55,7 +55,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTopEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -78,7 +78,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromBottomEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -101,8 +101,8 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromHorizontalEdgesOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -135,8 +135,8 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromVerticalEdgesOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -170,10 +170,10 @@ class ExpandFromEdgeTests: XCTestCase {
 
         let constraints = Constraid.expand(viewOne, fromEdgesOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/ExpandFromMarginTests.swift
+++ b/ConstraidTests/ExpandFromMarginTests.swift
@@ -9,7 +9,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromLeadingMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -32,7 +32,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTrailingMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -55,7 +55,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTopMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -78,7 +78,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromBottomMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -101,8 +101,8 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromHorizontalMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -135,8 +135,8 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromVerticalMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -170,10 +170,10 @@ class ExpandFromMarginTests: XCTestCase {
 
         let constraints = Constraid.expand(viewOne, fromMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/ExpandFromSizeTests.swift
+++ b/ConstraidTests/ExpandFromSizeTests.swift
@@ -8,7 +8,7 @@ class ExpandFromSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.expand(viewOne, fromWidthOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -29,7 +29,7 @@ class ExpandFromSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.expand(viewOne, fromHeightOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)

--- a/ConstraidTests/FlushWithEdgesTests.swift
+++ b/ConstraidTests/FlushWithEdgesTests.swift
@@ -10,7 +10,7 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withLeadingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -33,7 +33,7 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withTrailingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -56,7 +56,7 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withTopEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -79,7 +79,7 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withBottomEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -102,8 +102,8 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withVerticalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -137,8 +137,8 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withHorizontalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -172,10 +172,10 @@ class FlushWithEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/FlushWithMarginsTests.swift
+++ b/ConstraidTests/FlushWithMarginsTests.swift
@@ -10,7 +10,7 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withLeadingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -33,7 +33,7 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withTrailingMarginOf: viewTwo, times: 2.0, insetBy: 10.0,  priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -56,7 +56,7 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withTopMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -79,7 +79,7 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withBottomMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -102,8 +102,8 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withVerticalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -137,8 +137,8 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withHorizontalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
 
@@ -172,10 +172,10 @@ class FlushWithMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/LayoutGuideTests.swift
+++ b/ConstraidTests/LayoutGuideTests.swift
@@ -24,10 +24,10 @@ class LayoutGuideTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withEdgesOf: viewTwo.safeAreaLayoutGuide, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/LimitByEdgeTests.swift
+++ b/ConstraidTests/LimitByEdgeTests.swift
@@ -9,7 +9,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byLeadingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -32,7 +32,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTrailingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -55,7 +55,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTopEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -78,7 +78,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byBottomEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -101,8 +101,8 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byHorizontalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -135,8 +135,8 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byVerticalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -170,10 +170,10 @@ class LimitByEdgeTests: XCTestCase {
 
         let constraints = Constraid.limit(viewOne, byEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/LimitByMarginTests.swift
+++ b/ConstraidTests/LimitByMarginTests.swift
@@ -9,7 +9,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byLeadingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -32,7 +32,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTrailingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -55,7 +55,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTopMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -78,7 +78,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byBottomMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -101,8 +101,8 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byHorizontalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -135,8 +135,8 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byVerticalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints.last! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
+        let constraintTwo = viewOne.constraints.last!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.isActive, true)
@@ -170,10 +170,10 @@ class LimitByMarginTests: XCTestCase {
 
         let constraints = Constraid.limit(viewOne, byMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints[0] as NSLayoutConstraint
-        let constraintTwo = viewOne.constraints[1] as NSLayoutConstraint
-        let constraintThree = viewOne.constraints[2] as NSLayoutConstraint
-        let constraintFour = viewOne.constraints[3] as NSLayoutConstraint
+        let constraintOne = viewOne.constraints[0]
+        let constraintTwo = viewOne.constraints[1]
+        let constraintThree = viewOne.constraints[2]
+        let constraintFour = viewOne.constraints[3]
 
         XCTAssertEqual(constraints, viewOne.constraints)
 

--- a/ConstraidTests/ManageRelativePositionTests.swift
+++ b/ConstraidTests/ManageRelativePositionTests.swift
@@ -9,7 +9,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.follow(theTrailingMarginOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
@@ -31,7 +31,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.precede(theLeadingMarginOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
@@ -53,7 +53,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, aboveTheTopMarginOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -75,7 +75,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, belowTheBottomMarginOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -97,7 +97,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.follow(theTrailingEdgeOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
@@ -119,7 +119,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.precede(theLeadingEdgeOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraintOne = viewOne.constraints.first! as NSLayoutConstraint
+        let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraintOne.firstItem as! UIView, viewOne)
@@ -141,7 +141,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, aboveTheTopEdgeOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -163,7 +163,7 @@ class ManageRelativePositionTests: XCTestCase {
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, belowTheBottomEdgeOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)

--- a/ConstraidTests/ManageSizeTests.swift
+++ b/ConstraidTests/ManageSizeTests.swift
@@ -7,7 +7,7 @@ class ManageSizeTests: XCTestCase {
 
         let constraints = Constraid.setWidth(of: viewOne, to: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
 
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -44,7 +44,7 @@ class ManageSizeTests: XCTestCase {
         let viewOne = UIView()
 
         let constraints = Constraid.setHeight(of: viewOne, to: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -64,7 +64,7 @@ class ManageSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.matchWidth(of: viewOne, to: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -84,7 +84,7 @@ class ManageSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.matchHeight(of: viewOne, to: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
@@ -102,7 +102,7 @@ class ManageSizeTests: XCTestCase {
         let viewOne = UIView()
 
         let constraints = Constraid.equalize(viewOne, priority: Constraid.LayoutPriority(rawValue: 500))
-        let constraint = viewOne.constraints.first! as NSLayoutConstraint
+        let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
         XCTAssertEqual(constraint.firstItem as! UIView, viewOne)


### PR DESCRIPTION
I did this so that our tests are a bit cleaner since these actually no
longer do anything. Previously we used to return a collection of
ConstraidConstraint objects. However, now we simply return a collection
of NSLayoutConstraint objects as they are cross-platform. Hence, there
is no longer a reason to cast them to NSLayoutConstraint objects in
tests anymore.