### PR TITLE
Remove auto activate from manage size methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased][unreleased] -
 
+* Remove auto activate so that can be used with AutoLayout animations
 * Remove functionality of setWidth & setHeight removing previous width height constraints
 * Added `expandWidth` method
 

--- a/Constraid/CenterWithinEdges.swift
+++ b/Constraid/CenterWithinEdges.swift
@@ -74,7 +74,6 @@ public func center(_ itemA: Constraid.View, verticallyWithin itemB: Any?,
                                multiplier: multiplier, constant: (offset * -1), priority: priority)
         )
     }
-    collection.activate()
     return collection
 }
 
@@ -118,7 +117,6 @@ public func center(_ itemA: Constraid.View, horizontallyWithin itemB: Any?,
                                multiplier: multiplier, constant: (offset * -1), priority: priority)
         )
     }
-    collection.activate()
     return collection
 }
 
@@ -154,7 +152,6 @@ public func center(_ itemA: Constraid.View, within itemB: Any?,
             Constraid.center(itemA, verticallyWithin: itemB, times: multiplier,
                    offsetBy: offset, offsetDirection: .down,
                    priority: priority)
-        constraints.activate()
         return constraints
     case .upAndLeft:
         let constraints = Constraid.center(itemA, horizontallyWithin: itemB,
@@ -165,7 +162,6 @@ public func center(_ itemA: Constraid.View, within itemB: Any?,
                              times: multiplier,
                    offsetBy: offset, offsetDirection: .up,
                    priority: priority)
-        constraints.activate()
         return constraints
     }
 }

--- a/Constraid/CenterWithinMargins.swift
+++ b/Constraid/CenterWithinMargins.swift
@@ -46,7 +46,6 @@ public func center(_ itemA: Constraid.View, verticallyWithinMarginsOf itemB: Any
                                constant: (offset * -1), priority: priority)
         )
     }
-    collection.activate()
     return collection
 }
 
@@ -93,7 +92,6 @@ public func center(_ itemA: Constraid.View, horizontallyWithinMarginsOf itemB: A
                                constant: (offset * -1), priority: priority)
         )
     }
-    collection.activate()
     return collection
 }
 
@@ -130,7 +128,6 @@ public func center(_ itemA: Constraid.View, withinMarginsOf itemB: Any?,
             Constraid.center(itemA, verticallyWithinMarginsOf: itemB, times: multiplier,
                    offsetBy: offset, offsetDirection: .down,
                     priority: priority)
-        constraints.activate()
         return constraints
     case .upAndLeft:
         let constraints = Constraid.center(itemA, horizontallyWithinMarginsOf: itemB, times: multiplier,
@@ -139,7 +136,6 @@ public func center(_ itemA: Constraid.View, withinMarginsOf itemB: Any?,
             Constraid.center(itemA, verticallyWithinMarginsOf: itemB, times: multiplier,
                    offsetBy: offset, offsetDirection: .up,
                     priority: priority)
-        constraints.activate()
         return constraints
     }
 }

--- a/Constraid/CubByMargin.swift
+++ b/Constraid/CubByMargin.swift
@@ -30,7 +30,6 @@ public func cup(_ itemA: Constraid.View, byLeadingMarginOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .leading, relatedBy: .equal, toItem: itemB, attribute: .leadingMargin, multiplier: multiplier, constant: inset, priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .bottom, relatedBy: .equal, toItem: itemB, attribute: .bottomMargin, multiplier: multiplier, constant: (-1.0 * inset), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -61,7 +60,6 @@ public func cup(_ itemA: Constraid.View, byTrailingMarginOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .trailing, relatedBy: .equal, toItem: itemB, attribute: .trailingMargin, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .bottom, relatedBy: .equal, toItem: itemB, attribute: .bottomMargin, multiplier: multiplier, constant: (-1.0 * inset), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -92,7 +90,6 @@ public func cup(_ itemA: Constraid.View, byTopMarginOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .top, relatedBy: .equal, toItem: itemB, attribute: .topMargin, multiplier: multiplier, constant: inset, priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .trailing, relatedBy: .equal, toItem: itemB, attribute: .trailingMargin, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         ])
-    collection.activate()
     return collection
 }
 
@@ -123,6 +120,5 @@ public func cup(_ itemA: Constraid.View, byBottomMarginOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .bottom, relatedBy: .equal, toItem: itemB, attribute: .bottomMargin, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .trailing, relatedBy: .equal, toItem: itemB, attribute: .trailingMargin, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         ])
-    collection.activate()
     return collection
 }

--- a/Constraid/CupByEdge.swift
+++ b/Constraid/CupByEdge.swift
@@ -31,7 +31,6 @@ public func cup(_ itemA: Constraid.View, byLeadingEdgeOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .leading, relatedBy: .equal, toItem: itemB, attribute: .leading, multiplier: multiplier, constant: inset, priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .bottom, relatedBy: .equal, toItem: itemB, attribute: .bottom, multiplier: multiplier, constant: (-1.0 * inset), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -62,7 +61,6 @@ public func cup(_ itemA: Constraid.View, byTrailingEdgeOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .trailing, relatedBy: .equal, toItem: itemB, attribute: .trailing, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .bottom, relatedBy: .equal, toItem: itemB, attribute: .bottom, multiplier: multiplier, constant: (-1.0 * inset), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -93,7 +91,6 @@ public func cup(_ itemA: Constraid.View, byTopEdgeOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .top, relatedBy: .equal, toItem: itemB, attribute: .top, multiplier: multiplier, constant: inset, priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .trailing, relatedBy: .equal, toItem: itemB, attribute: .trailing, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         ])
-    collection.activate()
     return collection
 }
 
@@ -124,6 +121,5 @@ public func cup(_ itemA: Constraid.View, byBottomEdgeOf itemB: Any?,
         NSLayoutConstraint(item: itemA, attribute: .bottom, relatedBy: .equal, toItem: itemB, attribute: .bottom, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         NSLayoutConstraint(item: itemA, attribute: .trailing, relatedBy: .equal, toItem: itemB, attribute: .trailing, multiplier: multiplier, constant: (-1.0 * inset), priority: priority),
         ])
-    collection.activate()
     return collection
 }

--- a/Constraid/ExpandFromEdge.swift
+++ b/Constraid/ExpandFromEdge.swift
@@ -32,7 +32,6 @@ public func expand(_ itemA: Constraid.View, fromLeadingEdgeOf itemB: Any?,
                            attribute: .leading, multiplier: multiplier,
                            constant: offset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -65,7 +64,6 @@ public func expand(_ itemA: Constraid.View, fromTrailingEdgeOf itemB: Any?,
                            attribute: .trailing, multiplier: multiplier,
                            constant: (offset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -96,7 +94,6 @@ public func expand(_ itemA: Constraid.View, fromTopEdgeOf itemB: Any?,
                            relatedBy: .greaterThanOrEqual, toItem: itemB, attribute: .top,
                            multiplier: multiplier, constant: offset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -129,7 +126,6 @@ public func expand(_ itemA: Constraid.View, fromBottomEdgeOf itemB: Any?,
                            attribute: .bottom, multiplier: multiplier,
                            constant: (offset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -159,7 +155,6 @@ public func expand(_ itemA: Constraid.View, fromHorizontalEdgesOf itemB: Any?,
                             priority: priority) +
         Constraid.expand(itemA, fromBottomEdgeOf: itemB, times: multiplier, offsetBy: offset,
                priority: priority)
-    collection.activate()
     return collection
 }
 
@@ -188,7 +183,6 @@ public func expand(_ itemA: Constraid.View, fromVerticalEdgesOf itemB: Any?,
                             priority: priority) +
         Constraid.expand(itemA, fromTrailingEdgeOf: itemB, times: multiplier, offsetBy: offset,
                priority: priority)
-    collection.activate()
     return collection
 }
 
@@ -223,6 +217,5 @@ public func expand(_ itemA: Constraid.View, fromEdgesOf itemB: Any?,
                priority: priority) +
         Constraid.expand(itemA, fromTrailingEdgeOf: itemB, times: multiplier, offsetBy: offset,
                priority: priority)
-    collection.activate()
     return collection
 }

--- a/Constraid/ExpandFromMargin.swift
+++ b/Constraid/ExpandFromMargin.swift
@@ -32,7 +32,6 @@ public func expand(_ itemA: Constraid.View, fromLeadingMarginOf itemB: Any?,
                            attribute: .leadingMargin, multiplier: multiplier,
                            constant: offset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -65,7 +64,6 @@ public func expand(_ itemA: Constraid.View, fromTrailingMarginOf itemB: Any?,
                            attribute: .trailingMargin, multiplier: multiplier,
                            constant: (offset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -98,7 +96,6 @@ public func expand(_ itemA: Constraid.View, fromTopMarginOf itemB: Any?,
                            attribute: .topMargin, multiplier: multiplier,
                            constant: offset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -131,7 +128,6 @@ public func expand(_ itemA: Constraid.View, fromBottomMarginOf itemB: Any?,
                            attribute: .bottomMargin, multiplier: multiplier,
                            constant: (offset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -161,7 +157,6 @@ public func expand(_ itemA: Constraid.View, fromHorizontalMarginsOf itemB: Any?,
                             priority: priority) +
         Constraid.expand(itemA, fromBottomMarginOf: itemB, times: multiplier, offsetBy: offset,
                priority: priority)
-    collection.activate()
     return collection
 }
 
@@ -191,7 +186,6 @@ public func expand(_ itemA: Constraid.View, fromVerticalMarginsOf itemB: Any?,
                             priority: priority) +
         Constraid.expand(itemA, fromTrailingMarginOf: itemB, times: multiplier, offsetBy: offset,
                priority: priority)
-    collection.activate()
     return collection
 }
 
@@ -227,6 +221,5 @@ public func expand(_ itemA: Constraid.View, fromMarginsOf itemB: Any?,
                priority: priority) +
         Constraid.expand(itemA, fromTrailingMarginOf: itemB, times: multiplier, offsetBy: offset,
                priority: priority)
-    collection.activate()
     return collection
 }

--- a/Constraid/ExpandFromSize.swift
+++ b/Constraid/ExpandFromSize.swift
@@ -33,7 +33,6 @@ public func expand(_ itemA: Constraid.View, fromWidthOf itemB: Any?,
                            attribute: .width, multiplier: multiplier,
                            constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -66,6 +65,5 @@ public func expand(_ itemA: Constraid.View, fromHeightOf itemB: Any?,
                            attribute: .height, multiplier: multiplier,
                            constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }

--- a/Constraid/FlushWithEdges.swift
+++ b/Constraid/FlushWithEdges.swift
@@ -28,7 +28,6 @@ public func flush(_ itemA: Constraid.View, withLeadingEdgeOf itemB: Any?, times 
                            toItem: itemB, attribute: .leading, multiplier: multiplier,
                            constant: inset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -56,7 +55,6 @@ public func flush(_ itemA: Constraid.View, withTrailingEdgeOf itemB: Any?, times
                            toItem: itemB, attribute: .trailing, multiplier: multiplier,
                            constant: (-1.0 * inset), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -84,7 +82,6 @@ public func flush(_ itemA: Constraid.View, withTopEdgeOf itemB: Any?, times mult
                            toItem: itemB, attribute: .top, multiplier: multiplier,
                            constant: inset, priority: priority)
         ])
-    constraints.activate()
     return constraints
 }
 
@@ -112,7 +109,6 @@ public func flush(_ itemA: Constraid.View, withBottomEdgeOf itemB: Any?, times m
                            toItem: itemB, attribute: .bottom, multiplier: multiplier,
                            constant: (-1.0 * inset), priority: priority)
         ])
-    constraints.activate()
     return constraints
 }
 
@@ -138,7 +134,6 @@ public func flush(_ itemA: Constraid.View, withVerticalEdgesOf item: Any?, times
     let constraints = Constraid.flush(itemA, withLeadingEdgeOf: item, times: multiplier, insetBy: inset,
                                       priority: priority) +
         Constraid.flush(itemA, withTrailingEdgeOf: item, times: multiplier, insetBy: inset, priority: priority)
-    constraints.activate()
     return constraints
 }
 
@@ -165,7 +160,6 @@ public func flush(_ itemA: Constraid.View, withHorizontalEdgesOf item: Any?, tim
                                       priority: priority) +
         Constraid.flush(itemA, withBottomEdgeOf: item, times: multiplier, insetBy: inset,
                         priority: priority)
-    constraints.activate()
     return constraints
 }
 
@@ -193,6 +187,5 @@ public func flush(_ itemA: Constraid.View, withEdgesOf item: Any?, times multipl
                                       priority: priority) +
         Constraid.flush(itemA, withVerticalEdgesOf: item, times: multiplier, insetBy: inset,
                         priority: priority)
-    constraints.activate()
     return constraints
 }

--- a/Constraid/FlushWithMargins.swift
+++ b/Constraid/FlushWithMargins.swift
@@ -26,7 +26,6 @@ public func flush(_ itemA: Constraid.View, withLeadingMarginOf itemB: Any?, time
                            toItem: itemB, attribute: .leadingMargin, multiplier: multiplier,
                            constant: inset, priority: priority)
         ])
-    constraints.activate()
     return constraints
 }
 
@@ -53,7 +52,6 @@ public func flush(_ itemA: Constraid.View, withTrailingMarginOf itemB: Any?, tim
                            toItem: itemB, attribute: .trailingMargin, multiplier: multiplier,
                            constant: (-1.0 * inset), priority: priority)
         ])
-    constraints.activate()
     return constraints
 }
 
@@ -80,7 +78,6 @@ public func flush(_ itemA: Constraid.View, withTopMarginOf itemB: Any?, times mu
                            toItem: itemB, attribute: .topMargin, multiplier: multiplier,
                            constant: inset, priority: priority)
         ])
-    constraints.activate()
     return constraints
 }
 
@@ -107,7 +104,6 @@ public func flush(_ itemA: Constraid.View, withBottomMarginOf itemB: Any?, times
                            toItem: itemB, attribute: .bottomMargin, multiplier: multiplier,
                            constant: (-1.0 * inset), priority: priority)
         ])
-    constraints.activate()
     return constraints
 }
 
@@ -132,7 +128,6 @@ public func flush(_ itemA: Constraid.View, withVerticalMarginsOf itemB: Any?, ti
     let constraints = Constraid.flush(itemA, withLeadingMarginOf: itemB, times: multiplier, insetBy: inset,
                             priority: priority) +
         Constraid.flush(itemA, withTrailingMarginOf: itemB, times: multiplier, insetBy: inset, priority: priority)
-    constraints.activate()
     return constraints
 }
 
@@ -158,7 +153,6 @@ public func flush(_ itemA: Constraid.View, withHorizontalMarginsOf itemB: Any?, 
                             priority: priority) +
         Constraid.flush(itemA, withBottomMarginOf: itemB, times: multiplier, insetBy: inset,
                priority: priority)
-    constraints.activate()
     return constraints
 }
 
@@ -185,6 +179,5 @@ public func flush(_ itemA: Constraid.View, withMarginsOf itemB: Any?, times mult
                             priority: priority) +
         Constraid.flush(itemA, withVerticalMarginsOf: itemB, times: multiplier, insetBy: inset,
               priority: priority)
-    constraints.activate()
     return constraints
 }

--- a/Constraid/LimitByEdge.swift
+++ b/Constraid/LimitByEdge.swift
@@ -32,7 +32,6 @@ public func limit(_ itemA: Constraid.View, byLeadingEdgeOf itemB: Any?,
                            relatedBy: .lessThanOrEqual, toItem: itemB, attribute: .leading,
                            multiplier: multiplier, constant: inset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -65,7 +64,6 @@ public func limit(_ itemA: Constraid.View, byTrailingEdgeOf itemB: Any?,
                            attribute: .trailing, multiplier: multiplier,
                            constant: (inset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -97,7 +95,6 @@ public func limit(_ itemA: Constraid.View, byTopEdgeOf itemB: Any?,
                            relatedBy: .lessThanOrEqual, toItem: itemB, attribute: .top,
                            multiplier: multiplier, constant: inset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -130,7 +127,6 @@ public func limit(_ itemA: Constraid.View, byBottomEdgeOf itemB: Any?,
                            multiplier: multiplier, constant: (inset * -1),
                            priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -160,7 +156,6 @@ public func limit(_ itemA: Constraid.View, byHorizontalEdgesOf itemB: Any?,
                              priority: priority) +
         Constraid.limit(itemA, byBottomEdgeOf: itemB, times: multiplier, insetBy: inset,
                priority: priority)
-    constraints.activate()
     return constraints
 }
 
@@ -190,7 +185,6 @@ public func limit(_ itemA: Constraid.View, byVerticalEdgesOf itemB: Any?,
                             priority: priority) +
         Constraid.limit(itemA, byTrailingEdgeOf: itemB, times: multiplier, insetBy: inset,
               priority: priority)
-    constraints.activate()
     return constraints
 }
 
@@ -226,6 +220,5 @@ public func limit(_ itemA: Constraid.View, byEdgesOf itemB: Any?,
               priority: priority) +
         Constraid.limit(itemA, byTrailingEdgeOf: itemB, times: multiplier, insetBy: inset,
               priority: priority)
-    constraints.activate()
     return constraints
 }

--- a/Constraid/LimitByMargin.swift
+++ b/Constraid/LimitByMargin.swift
@@ -32,7 +32,6 @@ public func limit(_ itemA: Constraid.View, byLeadingMarginOf itemB: Any?,
                            attribute: .leadingMargin, multiplier: multiplier,
                            constant: inset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -65,7 +64,6 @@ public func limit(_ itemA: Constraid.View, byTrailingMarginOf itemB: Any?,
                            attribute: .trailingMargin, multiplier: multiplier,
                            constant: (inset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -98,7 +96,6 @@ public func limit(_ itemA: Constraid.View, byTopMarginOf itemB: Any?,
                            attribute: .topMargin, multiplier: multiplier,
                            constant: inset, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -130,7 +127,6 @@ public func limit(_ itemA: Constraid.View, byBottomMarginOf itemB: Any?,
                            attribute: .bottomMargin, multiplier: multiplier,
                            constant: (inset * -1), priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -159,7 +155,6 @@ public func limit(_ itemA: Constraid.View, byHorizontalMarginsOf itemB: Any?,
                            priority: priority) +
         Constraid.limit(itemA, byBottomMarginOf: itemB, times: multiplier, insetBy: inset,
               priority: priority)
-    collection.activate()
     return collection
 }
 
@@ -188,7 +183,6 @@ public func limit(_ itemA: Constraid.View, byVerticalMarginsOf itemB: Any?,
                            priority: priority) +
         Constraid.limit(itemA, byTrailingMarginOf: itemB, times: multiplier, insetBy: inset,
               priority: priority)
-    collection.activate()
     return collection
 }
 
@@ -223,6 +217,5 @@ public func limit(_ itemA: Constraid.View, byMarginsOf itemB: Any?,
               priority: priority) +
         Constraid.limit(itemA, byTrailingMarginOf: itemB, times: multiplier, insetBy: inset,
               priority: priority)
-    collection.activate()
     return collection
 }

--- a/Constraid/ManageRelativePosition.swift
+++ b/Constraid/ManageRelativePosition.swift
@@ -33,7 +33,6 @@
                                attribute: .trailingMargin, multiplier: multiplier,
                                constant: constant, priority: priority)
             ])
-        collection.activate()
         return collection
     }
 
@@ -69,7 +68,6 @@
                                multiplier: multiplier, constant: constant,
                                priority: priority)
             ])
-        collection.activate()
         return collection
     }
 
@@ -104,7 +102,6 @@
                                attribute: .topMargin, multiplier: multiplier,
                                constant: (-1.0 * constant), priority: priority)
             ])
-        collection.activate()
         return collection
     }
 
@@ -139,7 +136,6 @@
                                attribute: .bottomMargin, multiplier: multiplier,
                                constant: constant, priority: priority)
             ])
-        collection.activate()
         return collection
     }
 #else
@@ -177,7 +173,6 @@ public func follow(theTrailingEdgeOf itemB: Any?,
                            relatedBy: .equal, toItem: itemB, attribute: .trailing,
                            multiplier: multiplier, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -212,7 +207,6 @@ public func precede(theLeadingEdgeOf itemB: Any?,
                            relatedBy: .equal, toItem: itemB, attribute: .leading,
                            multiplier: multiplier, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -247,7 +241,6 @@ public func set(_ itemA: Constraid.View, aboveTheTopEdgeOf itemB: Any?,
                            multiplier: multiplier, constant: (-1.0 * constant),
                            priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -281,6 +274,5 @@ public func set(_ itemA: Constraid.View, belowTheBottomEdgeOf itemB: Any?,
                            toItem: itemB, attribute: .bottom, multiplier: multiplier,
                            constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }

--- a/Constraid/ManageSize.swift
+++ b/Constraid/ManageSize.swift
@@ -23,7 +23,6 @@ public func setWidth(of item: Constraid.View, to constant: CGFloat, priority: Co
                            relatedBy: .equal, toItem: nil, attribute: .notAnAttribute,
                            multiplier: 1.0, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -46,7 +45,6 @@ public func expandWidth(of item: Constraid.View, from constant: CGFloat, priorit
                            relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute,
                            multiplier: 1.0, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -69,7 +67,6 @@ public func setHeight(of item: Constraid.View, to constant: CGFloat, priority: C
                            relatedBy: .equal, toItem: nil, attribute: .notAnAttribute,
                            multiplier: 1.0, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -99,7 +96,6 @@ public func matchWidth(of itemA: Constraid.View, to itemB: Any?,
                            relatedBy: .equal, toItem: itemB, attribute: .width,
                            multiplier: multiplier, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -129,7 +125,6 @@ public func matchHeight(of itemA: Constraid.View, to itemB: Any?,
                            relatedBy: .equal, toItem: itemB, attribute: .height,
                            multiplier: multiplier, constant: constant, priority: priority)
         ])
-    collection.activate()
     return collection
 }
 
@@ -153,6 +148,5 @@ public func equalize(_ item: Constraid.View,
                            relatedBy: .equal, toItem: item, attribute: .height,
                            multiplier: 1.0, constant: 0.0, priority: priority)
         ])
-    collection.activate()
     return collection
 }

--- a/ConstraidTests/CenterWithinEdgesTests.swift
+++ b/ConstraidTests/CenterWithinEdgesTests.swift
@@ -9,6 +9,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithin: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .down, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -32,6 +33,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithin: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .up, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -55,6 +57,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithin: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .right, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -78,6 +81,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithin: viewTwo,  times: 2.0, offsetBy: 10.0, offsetDirection: .left,priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -101,6 +105,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, within: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .downAndRight, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
@@ -137,6 +142,7 @@ class CenterWithinEdgesTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, within: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .upAndLeft, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!

--- a/ConstraidTests/CenterWithinMarginsTests.swift
+++ b/ConstraidTests/CenterWithinMarginsTests.swift
@@ -9,6 +9,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .down, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -32,6 +33,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, verticallyWithinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .up, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -55,6 +57,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .right, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -78,6 +81,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, horizontallyWithinMarginsOf: viewTwo, times: 2.0,  offsetBy: 10.0, offsetDirection: .left,priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -101,6 +105,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, withinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .downAndRight, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
@@ -137,6 +142,7 @@ class CenterWithinMarginsTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.center(viewOne, withinMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, offsetDirection: .upAndLeft, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!

--- a/ConstraidTests/CupByEdgeTests.swift
+++ b/ConstraidTests/CupByEdgeTests.swift
@@ -8,6 +8,7 @@ class CupByEdgeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byLeadingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]
@@ -54,6 +55,7 @@ class CupByEdgeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTrailingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]
@@ -100,6 +102,7 @@ class CupByEdgeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTopEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]
@@ -146,6 +149,7 @@ class CupByEdgeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byBottomEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/CupByMarginTests.swift
+++ b/ConstraidTests/CupByMarginTests.swift
@@ -8,6 +8,7 @@ class CupByMarginTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byLeadingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]
@@ -54,6 +55,7 @@ class CupByMarginTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTrailingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]
@@ -100,6 +102,7 @@ class CupByMarginTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byTopMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]
@@ -146,6 +149,7 @@ class CupByMarginTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.cup(viewOne, byBottomMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/ExpandFromEdgeTests.swift
+++ b/ConstraidTests/ExpandFromEdgeTests.swift
@@ -9,6 +9,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromLeadingEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -32,6 +33,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTrailingEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -55,6 +57,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTopEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -78,6 +81,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromBottomEdgeOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -101,6 +105,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromHorizontalEdgesOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -135,6 +140,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromVerticalEdgesOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -169,6 +175,7 @@ class ExpandFromEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromEdgesOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/ExpandFromMarginTests.swift
+++ b/ConstraidTests/ExpandFromMarginTests.swift
@@ -9,6 +9,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromLeadingMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -32,6 +33,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTrailingMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -55,6 +57,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromTopMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -78,6 +81,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromBottomMarginOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -101,6 +105,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromHorizontalMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -135,6 +140,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromVerticalMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -169,6 +175,7 @@ class ExpandFromMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.expand(viewOne, fromMarginsOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/ExpandFromSizeTests.swift
+++ b/ConstraidTests/ExpandFromSizeTests.swift
@@ -8,6 +8,7 @@ class ExpandFromSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.expand(viewOne, fromWidthOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -29,6 +30,7 @@ class ExpandFromSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.expand(viewOne, fromHeightOf: viewTwo, times: 2.0, offsetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)

--- a/ConstraidTests/FlushWithEdgesTests.swift
+++ b/ConstraidTests/FlushWithEdgesTests.swift
@@ -9,6 +9,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withLeadingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -32,6 +33,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withTrailingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -55,6 +57,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withTopEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -78,6 +81,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withBottomEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -101,6 +105,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withVerticalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
@@ -136,6 +141,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withHorizontalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
@@ -171,6 +177,7 @@ class FlushWithEdgesTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/FlushWithMarginsTests.swift
+++ b/ConstraidTests/FlushWithMarginsTests.swift
@@ -9,6 +9,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withLeadingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -32,6 +33,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withTrailingMarginOf: viewTwo, times: 2.0, insetBy: 10.0,  priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -55,6 +57,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withTopMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -78,6 +81,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withBottomMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -101,6 +105,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withVerticalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
@@ -136,6 +141,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withHorizontalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
@@ -171,6 +177,7 @@ class FlushWithMarginsTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = flush(viewOne, withMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/LayoutGuideTests.swift
+++ b/ConstraidTests/LayoutGuideTests.swift
@@ -23,6 +23,7 @@ class LayoutGuideTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.flush(viewOne, withEdgesOf: viewTwo.safeAreaLayoutGuide, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/LimitByEdgeTests.swift
+++ b/ConstraidTests/LimitByEdgeTests.swift
@@ -9,6 +9,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byLeadingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -32,6 +33,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTrailingEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -55,6 +57,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTopEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -78,6 +81,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byBottomEdgeOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -101,6 +105,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byHorizontalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -135,6 +140,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byVerticalEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -169,6 +175,7 @@ class LimitByEdgeTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byEdgesOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/LimitByMarginTests.swift
+++ b/ConstraidTests/LimitByMarginTests.swift
@@ -9,6 +9,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byLeadingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -32,6 +33,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTrailingMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -55,6 +57,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byTopMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -78,6 +81,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byBottomMarginOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -101,6 +105,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byHorizontalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -135,6 +140,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byVerticalMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraintOne = viewOne.constraints.first!
         let constraintTwo = viewOne.constraints.last!
 
@@ -169,6 +175,7 @@ class LimitByMarginTests: XCTestCase {
         viewOne.addSubview(viewTwo)
 
         let constraints = Constraid.limit(viewOne, byMarginsOf: viewTwo, times: 2.0, insetBy: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints[0]
         let constraintTwo = viewOne.constraints[1]

--- a/ConstraidTests/ManageRelativePositionTests.swift
+++ b/ConstraidTests/ManageRelativePositionTests.swift
@@ -8,6 +8,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.follow(theTrailingMarginOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -30,6 +31,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.precede(theLeadingMarginOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -52,6 +54,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, aboveTheTopMarginOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraint = viewOne.constraints.first!
 
@@ -74,6 +77,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, belowTheBottomMarginOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraint = viewOne.constraints.first!
 
@@ -96,6 +100,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.follow(theTrailingEdgeOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -118,6 +123,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.precede(theLeadingEdgeOf: viewTwo, with: viewOne, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraintOne = viewOne.constraints.first!
 
@@ -140,6 +146,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, aboveTheTopEdgeOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraint = viewOne.constraints.first!
 
@@ -162,6 +169,7 @@ class ManageRelativePositionTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.set(viewOne, belowTheBottomEdgeOf: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraint = viewOne.constraints.first!
 

--- a/ConstraidTests/ManageSizeTests.swift
+++ b/ConstraidTests/ManageSizeTests.swift
@@ -6,6 +6,7 @@ class ManageSizeTests: XCTestCase {
         let viewOne = UIView()
 
         let constraints = Constraid.setWidth(of: viewOne, to: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraint = viewOne.constraints.first!
 
@@ -25,6 +26,7 @@ class ManageSizeTests: XCTestCase {
         let viewOne = UIView()
 
         let constraints = Constraid.expandWidth(of: viewOne, from: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
 
         let constraint = viewOne.constraints.first!
 
@@ -44,6 +46,7 @@ class ManageSizeTests: XCTestCase {
         let viewOne = UIView()
 
         let constraints = Constraid.setHeight(of: viewOne, to: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -64,6 +67,7 @@ class ManageSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.matchWidth(of: viewOne, to: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -84,6 +88,7 @@ class ManageSizeTests: XCTestCase {
 
         viewOne.addSubview(viewTwo)
         let constraints = Constraid.matchHeight(of: viewOne, to: viewTwo, times: 2.0, by: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)
@@ -102,6 +107,7 @@ class ManageSizeTests: XCTestCase {
         let viewOne = UIView()
 
         let constraints = Constraid.equalize(viewOne, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
         let constraint = viewOne.constraints.first!
 
         XCTAssertEqual(constraints, viewOne.constraints)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,19 @@ NSLayoutConstraint.activate([
 However, with the aid of [Constraid][constraid] it is as simple as
 
 ```swift
-flush(childView, withVerticalEdgesOf: parentView)
+flush(childView, withVerticalEdgesOf: parentView).activate()
 ```
+
+or if you want to combine constraint collections you can do so as follows:
+
+```swift
+let constraints = flush(childView, withVerticalEdgesOf: parentView) +
+                  center(childView, verticallyWithin: parentView)
+constraints.activate()
+```
+
+The above is extremely useful when doing AutoLayout Animation or when you
+simply want to deactivate or activate a collection of constraints.
 
 <img src="resources/mascot_woman.png" alt="Crazy Woman in Straight Jacket" align="right">
 


### PR DESCRIPTION
I did this because we decided that we didn't want to support auto
activate any longer as it interferes with the AutoLayout animation use
cases. Also, we wanted to promote more use of constraint collection
composition and activation/deactivation.

I also add an example of having to activate in README so people weren't
just clueless about what the expectations where. I also added an example
of constraint collection composition as we wanted to promote that now.