### PR TITLE
Add expandHeight() method

### DIFF
--- a/Constraid/ManageSize.swift
+++ b/Constraid/ManageSize.swift
@@ -71,6 +71,28 @@ public func setHeight(of item: Constraid.View, to constant: CGFloat, priority: C
 }
 
 /**
+ Expand height of receiver using a constraint in auto-layout
+
+ - parameter item: The `item` you want to constrain
+ - parameter constant: The minimum height to expand from
+ - parameter priority: The priority this constraint uses when being
+ evaluated against other constraints
+
+ - returns: Constraint collection containing the generated constraint
+ */
+@discardableResult
+public func expandHeight(of item: Constraid.View, from constant: CGFloat, priority: Constraid.LayoutPriority = Constraid.LayoutPriorityRequired) -> Constraid.ConstraintCollection {
+
+    item.translatesAutoresizingMaskIntoConstraints = false
+    let collection = Constraid.ConstraintCollection([
+        NSLayoutConstraint(item: item, attribute: .height,
+                           relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute,
+                           multiplier: 1.0, constant: constant, priority: priority)
+        ])
+    return collection
+}
+
+/**
  Set width of receiver to width of `item`
 
  - parameter itemA: The `item` you want to constrain in relation to another object

--- a/ConstraidTests/ManageSizeTests.swift
+++ b/ConstraidTests/ManageSizeTests.swift
@@ -61,6 +61,26 @@ class ManageSizeTests: XCTestCase {
         XCTAssertEqual(viewOne.translatesAutoresizingMaskIntoConstraints, false)
     }
 
+    func testExpandHeight() {
+        let viewOne = UIView()
+
+        let constraints = Constraid.expandHeight(of: viewOne, from: 10.0, priority: Constraid.LayoutPriority(rawValue: 500))
+        constraints.activate()
+
+        let constraint = viewOne.constraints.first!
+
+        XCTAssertEqual(constraints, viewOne.constraints)
+        XCTAssertEqual(constraint.firstItem as! UIView, viewOne)
+        XCTAssertEqual(constraint.firstAttribute, NSLayoutAttribute.height)
+        XCTAssertEqual(constraint.relation, NSLayoutRelation.greaterThanOrEqual)
+        XCTAssertNil(constraint.secondItem)
+        XCTAssertEqual(constraint.secondAttribute, NSLayoutAttribute.notAnAttribute)
+        XCTAssertEqual(constraint.constant, 10.0)
+        XCTAssertEqual(constraint.priority, UILayoutPriority(rawValue: UILayoutPriority.RawValue(500)))
+
+        XCTAssertEqual(viewOne.translatesAutoresizingMaskIntoConstraints, false)
+    }
+
     func testMatchWidthOf() {
         let viewOne = UIView()
         let viewTwo = UIView()


### PR DESCRIPTION
So that users can expand the height of a view relative to a constant
value. This relates to issue #66.